### PR TITLE
Update lazy.nvim install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Changing colorscheme with and without `bg.nvim`_
 -- Packer
 use({ "typicode/bg.nvim" })
 -- Lazy
-"typicode/bg.nvim"
+{ "typicode/bg.nvim", lazy = false }
 ```
 
 ## How it works


### PR DESCRIPTION
If user set `defaults = { lazy = true }` in lazy.nvim configuration, this plugin _and especially #2_ won't work properly, so we can suggest using `lazy = false` in plugin configuration to fix this.