### PR TITLE
fix: do not create `not a tty` file (#7)

### DIFF
--- a/plugin/bg.lua
+++ b/plugin/bg.lua
@@ -2,6 +2,10 @@ local handle = io.popen("tty")
 local tty = handle:read("*a")
 handle:close()
 
+if tty == "" or tty:match("not a tty") then
+	return
+end
+
 local reset = function()
 	os.execute('printf "\\033]111\\007" > ' .. tty)
 end


### PR DESCRIPTION
Hello,

thank you for the wonderful plugin!

I've addressed an issue in bg.nvim where, in the absence of a tty, a file named not gets inadvertently created.

This happens because when there's no tty present, the response is `not a tty`, and when executing `os.execute('printf "\\033]111\\007" > ' .. tty)`, a file named not is created and written to.

```bash
~ $ tty
not a tty
```

To prevent the automatic creation of this not file, I've made adjustments to return early if the tty response is not a tty.


I'm not entirely sure if this is the best solution, but I wanted to make sure the not file doesn't get created.

thank you