### PR TITLE
Add VimSuspend to background reset conditions

### DIFF
--- a/plugin/bg.lua
+++ b/plugin/bg.lua
@@ -36,7 +36,7 @@ end
 
 local setup = function()
 	vim.api.nvim_create_autocmd({ "ColorScheme", "UIEnter" }, { callback = update })
-	vim.api.nvim_create_autocmd({ "VimLeavePre" }, { callback = reset })
+	vim.api.nvim_create_autocmd({ "VimLeavePre", "VimSuspend" }, { callback = reset })
 end
 
 setup()


### PR DESCRIPTION
Currently when suspending Vim to the background with `Ctrl + Z`, it does not restore the background settings to default. The addition of `VimSuspend` resolves this issue.